### PR TITLE
Update Site for post-Pinnacle 2021 copy; Add mailing list users via a GET request

### DIFF
--- a/src/components/Description.svelte
+++ b/src/components/Description.svelte
@@ -3,8 +3,8 @@
 	<div class="container inner">
 		<h2>What is Pinnacle?</h2>
 		<div class="body">
-			<p>Pinnacle invites a winning team from each of the world’s largest 50 collegiate hackathons and 5 high school hackathons to compete in an epic hack-off. This year, Pinnacle will be taking place on September 17-19 in Dallas, TX.</p>
-			<p>Our participants, who represent the brightest developers, designers, and creators in the nation, have received invitations throughout the Pinnacle 2020-2021 hackathon season. The Pinnacle 2020-2021 season has ended, and Pinnacle 2021 will be taking place on September 17-19, 2021. The next Pinnacle season will be announced soon.</p>
+			<p>Pinnacle invites the winning team from each of the world’s largest 50 collegiate hackathons and 5 high school hackathons to compete in an epic hack-off. Pinnacle 2021 took place on September 17-19, 2021 in Dallas, TX.</p>
+			<p>Our participants, who represent the brightest developers, designers, and creators in the nation, received invitations throughout the Pinnacle 2020-2021 hackathon season. While the Pinnacle 2020-2021 season has ended, the Pinnacle 2021-2022 season will be announced soon.</p>
 		</div>
 	</div>
 </section>

--- a/src/components/Hero.svelte
+++ b/src/components/Hero.svelte
@@ -15,8 +15,8 @@
 		<img src="https://static.pinnacle.us.org/2021/assets/textLogo.png" alt="Pinnacle" class="label"/>
 		<p class="byline">The Olympics of Hackathons</p>
 		<p class="dateline">
-			<span>September 17-19, 2021</span><br>
-			<span>Dallas, Texas</span>
+			<span></span><br>
+			<span></span>
 		</p>
 	</div>
 	<div id="scroll-prompt">

--- a/src/components/Timeline.svelte
+++ b/src/components/Timeline.svelte
@@ -13,7 +13,7 @@
 			<span class="timeline-date">September 17-19, 2021</span>
 			<span class="timeline-desc flex">
 				<p>Pinnacle 2021 event takes place.</p>
-				<p>Click <a href="https://www.twitch.tv/pinnacleusorg/videos?filter=highlights&sort=time" target="_blank">here</a> to watch the recordings from the livestream.</p>
+				<p><a href="https://www.twitch.tv/pinnacleusorg/videos?filter=highlights&sort=time" target="_blank">Click here to watch the recordings from the livestream.</a></p>
 			</span>
 		</div>
 	</div>
@@ -42,6 +42,10 @@
 
 		p {
 			margin-top: 0;
+		}
+
+		a {
+			text-decoration: underline;
 		}
 	}
 

--- a/src/components/Timeline.svelte
+++ b/src/components/Timeline.svelte
@@ -13,7 +13,7 @@
 			<span class="timeline-date">September 17-19, 2021</span>
 			<span class="timeline-desc flex">
 				<p>Pinnacle 2021 event takes place.</p>
-				<p>Click <a href="https://www.twitch.tv/pinnacleusorg/videos?filter=highlights&sort=time">here</a> to watch the recordings from the livestream.</p>
+				<p>Click <a href="https://www.twitch.tv/pinnacleusorg/videos?filter=highlights&sort=time" target="_blank">here</a> to watch the recordings from the livestream.</p>
 			</span>
 		</div>
 	</div>

--- a/src/components/Timeline.svelte
+++ b/src/components/Timeline.svelte
@@ -11,7 +11,10 @@
 		</div>
 		<div class="flex-smart">
 			<span class="timeline-date">September 17-19, 2021</span>
-			<span class="timeline-desc flex">Watch the world's best hackers face off at Pinnacle, live from Dallas.</span>
+			<span class="timeline-desc flex">
+				<p>Pinnacle 2021 event takes place.</p>
+				<p>Click <a href="https://www.twitch.tv/pinnacleusorg/videos?filter=highlights&sort=time">here</a> to watch the recordings from the livestream.</p>
+			</span>
 		</div>
 	</div>
 </section>

--- a/src/routes/mailing.svelte
+++ b/src/routes/mailing.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import Header from "../core/components/Header.svelte";
+	import Footer from "../components/Footer.svelte";
+
+	import { onMount } from "svelte";
+
+	//fetch API root
+	import { stores } from "@sapper/app";
+	const { session } = stores();
+	const { API_ROOT } = $session;
+
+	onMount(() => {
+		const urlParams = new URLSearchParams(window.location.search);
+		const userEmail = urlParams.get("email");
+		const userName = urlParams.get("name");
+		if (userEmail && userName) {
+			fetch(API_ROOT + "/contacts", {
+				method: "post",
+				body: JSON.stringify({
+					email: userEmail.trim(),
+					name: userName.trim(),
+				}),
+				headers: new Headers({ "Content-Type": "application/json" }),
+			}); // fail silently
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Pinnacle • Mailing List</title>
+</svelte:head>
+
+<div class="light-bg">
+	<Header />
+	<section class="container component-section">
+		<a href="/">&lsaquo; Home</a>
+		<h2>Welcome to the Mailing List</h2>
+		<p>
+			You've been enrolled in our mailing list, the best way to stay
+			up-to-date with the latest Pinnacle news. We don't send too many
+			emails, but if you'd wish to unsubscribe, you may follow the
+			unsubscribe link found in the footer of every email we send.
+		</p>
+	</section>
+	<Footer showLegal={false} />
+</div>
+
+<style lang="scss">
+	a {
+		text-decoration: none;
+	}
+
+	.container {
+		max-width: 900px;
+		padding-left: 30px;
+		padding-right: 30px;
+	}
+</style>


### PR DESCRIPTION
This change, if merged, will update the base copy on the Pinnacle landing with post-event text, as well as enable a new page that will allow us to onboard users into the mailing list via a GET request, instead of the standard POST request necessary to complete the registration form.